### PR TITLE
feat: add FEEL syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [lang-feel](https://github.com/nikku/lang-feel) are docum
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: turn into pure ES module ([#26](https://github.com/nikku/lang-feel/pull/26))
+* `FEAT`: add FEEL syntax highlighting ([#31](https://github.com/nikku/lang-feel/pull/31))
 * `DEPS`: update to `lezer-feel@2.0.0`
 * `DEPS`: update to `@lezer/common@1.4.0`
 * `DEPS`: update to `@codemirror/autocomplete@6.20.0`

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@codemirror/autocomplete": "^6.20.1",
         "@codemirror/language": "^6.12.3",
         "@lezer/common": "^1.5.2",
+        "@lezer/highlight": "^1.0.0",
         "lezer-feel": "^2.4.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@codemirror/autocomplete": "^6.20.1",
     "@codemirror/language": "^6.12.3",
     "@lezer/common": "^1.5.2",
+    "@lezer/highlight": "^1.0.0",
     "lezer-feel": "^2.4.0"
   },
   "devDependencies": {

--- a/src/highlight-style.ts
+++ b/src/highlight-style.ts
@@ -1,0 +1,45 @@
+import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { tags as t } from '@lezer/highlight';
+
+const feelHighlightStyle = HighlightStyle.define([
+  { tag: t.controlKeyword, color: '#af00db', fontWeight: 'bold' },
+  { tag: t.operatorKeyword, color: '#0000ff', fontWeight: 'bold' },
+  { tag: t.definitionKeyword, color: '#0000ff', fontWeight: 'bold' },
+  { tag: t.keyword, color: '#0000ff' },
+
+  { tag: t.string, color: '#a31515' },
+  { tag: t.special(t.string), color: '#a31515' },
+  { tag: t.number, color: '#087c52' },
+  { tag: t.bool, color: '#0000ff' },
+  { tag: t.null, color: '#0000ff' },
+
+  { tag: t.typeName, color: '#247891' },
+
+  { tag: t.variableName, color: '#0070c1' },
+  { tag: t.definition(t.variableName), color: '#0070c1' },
+  { tag: t.special(t.variableName), color: '#0000ff' },
+
+  { tag: t.function(t.variableName), color: '#795e26' },
+  { tag: t.function(t.special(t.variableName)), color: '#795e26' },
+  { tag: t.function(t.definition(t.variableName)), color: '#795e26' },
+  { tag: t.function(t.propertyName), color: '#795e26' },
+
+  { tag: t.definition(t.propertyName), color: '#0070c1' },
+  { tag: t.definition(t.literal), color: '#383a42' },
+
+  { tag: t.arithmeticOperator, color: '#383a42' },
+  { tag: t.compareOperator, color: '#383a42' },
+
+  { tag: t.lineComment, color: '#008000', fontStyle: 'italic' },
+  { tag: t.blockComment, color: '#008000', fontStyle: 'italic' },
+
+  { tag: t.list, color: '#383a42' },
+  { tag: t.paren, color: '#383a42' },
+  { tag: t.squareBracket, color: '#383a42' },
+  { tag: t.brace, color: '#383a42' },
+  { tag: t.derefOperator, color: '#383a42' },
+  { tag: t.separator, color: '#383a42' },
+  { tag: t.punctuation, color: '#383a42' }
+]);
+
+export const feelHighlighting = syntaxHighlighting(feelHighlightStyle);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,7 @@ export {
 } from './snippets.js';
 
 export * from './completion.js';
+
+export {
+  feelHighlighting
+} from './highlight-style.js';

--- a/test/highlight-style-spec.ts
+++ b/test/highlight-style-spec.ts
@@ -1,0 +1,73 @@
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { ensureSyntaxTree } from '@codemirror/language';
+
+import {
+  feel,
+  feelHighlighting
+} from 'lang-feel';
+
+import { expect } from 'chai';
+
+
+describe('highlight-style', function() {
+
+  let parent: Element;
+
+  beforeEach(function() {
+    parent = document.createElement('div');
+    document.body.appendChild(parent);
+  });
+
+  afterEach(function() {
+    parent.remove();
+  });
+
+
+  describe('styled rendering', function() {
+
+    function getSpanByText(doc: string, text: string) {
+      const view = new EditorView({
+        state: EditorState.create({
+          doc,
+          extensions: [
+            feel({ dialect: 'expression' }),
+            feelHighlighting
+          ]
+        }),
+        parent
+      });
+
+      ensureSyntaxTree(view.state, doc.length, 5000);
+      view.dispatch();
+
+      const spans = parent.querySelectorAll('.cm-line span');
+      const span = Array.from(spans).find(s => s.textContent === text);
+
+      return { span, view };
+    }
+
+    it('should style keywords', function() {
+      const { span, view } = getSpanByText('for x in [1] return x', 'for');
+      expect(span, 'for keyword should exist').to.exist;
+      expect(window.getComputedStyle(span!).color).to.equal('rgb(175, 0, 219)');
+      view.destroy();
+    });
+
+    it('should style strings', function() {
+      const { span, view } = getSpanByText('"hello"', '"hello"');
+      expect(span, 'string should exist').to.exist;
+      expect(window.getComputedStyle(span!).color).to.equal('rgb(163, 21, 21)');
+      view.destroy();
+    });
+
+    it('should style variables', function() {
+      const { span, view } = getSpanByText('x', 'x');
+      expect(span, 'variable should exist').to.exist;
+      expect(window.getComputedStyle(span!).color).to.equal('rgb(0, 112, 193)');
+      view.destroy();
+    });
+
+  });
+
+});


### PR DESCRIPTION
`lang-feel` wasn't providing the consumers with a ready-to-use theme out of the box for consistency. This pull request aims to introduce one to streamline the look.

The syntax highlighting theme is the same of VS Code Light with some alterations, which listed below, to suit it on both backgrounds where we use them.

- **Numbers**: #098658 -> #087c52 (darkened/reduced lightness by %2)
- **Types**: #267f99 -> #247891 (darkened/reduced lightness by %2)

And some alterations for the font weight and style to make it easier to digest the expressions.

As always, happy to receive suggestions for token color updates or theme names (from vscode themes, jetbrains themes or so) to demonstrate the highlighting with those.

**Sample screenshots** from the downstreams

**After**

<img width="307" alt="variable-outline" src="https://github.com/user-attachments/assets/b0755360-d8f0-45d7-8d4e-8baa22f0f21b" />

<img width="307" alt="bpmn-js-properties-panel" src="https://github.com/user-attachments/assets/663dffe4-9074-449d-8770-7d4ffeac8f35" />


**Note**: bpmn-js-properties-panel overrides "bold" text not to be "bold". This will be handled separately.

**Before**

<img width="307" alt="feel-editor" src="https://github.com/user-attachments/assets/ba3d1ca4-6509-49dc-842d-8be906721817" />


### Which issue does this PR address?

Related to [camunda/camunda-modeler#5938](https://github.com/camunda/camunda-modeler/issues/5938)
