### PR TITLE
fix: allow to complete literals from partial tokens

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -55,21 +55,32 @@ export const keywordCompletions = [
   })
 ];
 
-export const dontComplete = [
-  'StringLiteral', 'Identifier',
+export const dontCompleteLiteral = [
+  'StringLiteral',
   'LineComment', 'BlockComment',
   'PathExpression', 'Context',
   'Key', 'ParameterName'
 ];
 
-export const doComplete = [
+export const dontCompleteExpression = [
+  'Identifier',
+  ...dontCompleteLiteral
+];
+
+export const doCompleteExpression = [
   'Expr',
   'ContextEntry'
 ];
 
-export function ifExpression(completionSource: CompletionSource) : CompletionSource {
+export function ifNode(completionSource: CompletionSource, {
+  include,
+  exclude
+} : {
+  include: string[],
+  exclude: string[]
+}) {
 
-  const allNodes = [ ...dontComplete, ...doComplete ];
+  const allNodes = [ ...exclude, ...include ];
 
   return (context: CompletionContext) => {
 
@@ -81,7 +92,7 @@ export function ifExpression(completionSource: CompletionSource) : CompletionSou
 
       const [ _, name ] = match;
 
-      if (dontComplete.includes(name)) {
+      if (exclude.includes(name)) {
         return null;
       }
     }
@@ -90,10 +101,69 @@ export function ifExpression(completionSource: CompletionSource) : CompletionSou
   };
 }
 
+export function ifExpression(completionSource: CompletionSource) : CompletionSource {
+  return ifNode(completionSource, {
+    include: doCompleteExpression,
+    exclude: dontCompleteExpression
+  });
+}
+
+export function ifExpressionOrIdentifier(completionSource: CompletionSource) : CompletionSource {
+  return ifNode(completionSource, {
+    include: doCompleteExpression,
+    exclude: dontCompleteLiteral
+  });
+}
+
+export function combineCompletionSources(sources: CompletionSource[]) : CompletionSource {
+
+  return async (context) => {
+    const results = await Promise.all(
+      sources.map(source => source(context))
+    );
+
+    const matchedResults = results.filter(r => !!r);
+
+    if (!matchedResults.length) {
+      return null;
+    }
+
+    if (matchedResults.length === 1) {
+      return matchedResults[0];
+    }
+
+    return {
+      from: Math.min(...matchedResults.map(r => r.from)),
+      options: matchedResults.flatMap(r => r.options)
+    };
+  };
+}
+
 export function snippetCompletion(snippets: readonly Completion[]) : CompletionSource {
-  return ifExpression(
-    completeFromList(snippets.map(s => ({ ...s, type: 'text' })))
-  );
+
+  const taggedSnippets = snippets.map(s => ({ ...s, type: 'text' }));
+
+  // split literal completions from other completions
+  // literal completions may appear in place of <Identifier> nodes,
+  // other snippets may only appear in place of <Expression> nodes
+  const literalSnippets = taggedSnippets.filter(s => s.detail === 'literal');
+  const regularSnippets = taggedSnippets.filter(s => s.detail !== 'literal');
+
+  const sources: CompletionSource[] = [];
+
+  if (regularSnippets.length) {
+    sources.push(ifExpression(
+      completeFromList(regularSnippets)
+    ));
+  }
+
+  if (literalSnippets.length) {
+    sources.push(ifExpressionOrIdentifier(
+      completeFromList(literalSnippets)
+    ));
+  }
+
+  return combineCompletionSources(sources);
 }
 
 export function matchLeft(node: SyntaxNode, position: number, nodes: (string|undefined)[]) : SyntaxNode | null {

--- a/test/autocomplete-spec.ts
+++ b/test/autocomplete-spec.ts
@@ -1,5 +1,5 @@
 import { EditorSelection, EditorState } from '@codemirror/state';
-import { feel } from 'lang-feel';
+import { feel, snippetCompletion } from 'lang-feel';
 import { CompletionSource, autocompletion, currentCompletions, startCompletion } from '@codemirror/autocomplete';
 import { EditorView } from '@codemirror/view';
 import { basicSetup } from 'codemirror';
@@ -93,6 +93,33 @@ describe('feel completion', function() {
       expectedCompletions: [
         { label: 'if' },
         { label: 'context' }
+      ]
+    }));
+
+
+    it('completes <null> literal value', check({
+      doc: 'nu',
+      selection: 2,
+      expectedCompletions: [
+        { label: 'null' }
+      ]
+    }));
+
+
+    it('completes <true> literal value', check({
+      doc: 'tr',
+      selection: 2,
+      expectedCompletions: [
+        { label: 'true' }
+      ]
+    }));
+
+
+    it('completes <false> literal value', check({
+      doc: 'fa',
+      selection: 2,
+      expectedCompletions: [
+        { label: 'false' }
       ]
     }));
 
@@ -196,6 +223,63 @@ describe('feel completion', function() {
         { label: 'if', excluded: true },
         { label: 'some', excluded: true },
         { label: 'every', excluded: true }
+      ]
+    }));
+
+  });
+
+
+  describe('snippet completion', function() {
+
+    it('combines literal and regular completions', check({
+      doc: '',
+      config: {
+        completions: [
+          snippetCompletion([
+            { label: 'myRegular' },
+            { label: 'myLiteral', detail: 'literal' }
+          ])
+        ]
+      },
+      expectedCompletions: [
+        { label: 'myRegular' },
+        { label: 'myLiteral' }
+      ]
+    }));
+
+
+    it('completes only literal completions inside identifier', check({
+      doc: 'my',
+      selection: 2,
+      config: {
+        completions: [
+          snippetCompletion([
+            { label: 'myRegular' },
+            { label: 'myLiteral', detail: 'literal' }
+          ])
+        ]
+      },
+      expectedCompletions: [
+        { label: 'myRegular', excluded: true },
+        { label: 'myLiteral' }
+      ]
+    }));
+
+
+    it('returns no completion if context does not match', check({
+      doc: '"foo"',
+      selection: 2,
+      config: {
+        completions: [
+          snippetCompletion([
+            { label: 'myRegular' },
+            { label: 'myLiteral', detail: 'literal' }
+          ])
+        ]
+      },
+      expectedCompletions: [
+        { label: 'myRegular', excluded: true },
+        { label: 'myLiteral', excluded: true }
       ]
     }));
 


### PR DESCRIPTION
### Which issue does this PR address?

Allows partial completion of literals - when `n` is typed, then `null` is an available option:

<img width="1208" height="451" alt="capture ZOWD8G_optimized" src="https://github.com/user-attachments/assets/0622f9bf-f02b-4bda-a5d7-0d31289db990" />
