### PR TITLE
Complete any snippet on partial tokens

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -55,16 +55,12 @@ export const keywordCompletions = [
   })
 ];
 
-export const dontCompleteLiteral = [
+export const dontCompleteExpression = [
+  'Name',
   'StringLiteral',
   'LineComment', 'BlockComment',
   'PathExpression', 'Context',
   'Key', 'ParameterName'
-];
-
-export const dontCompleteExpression = [
-  'Identifier',
-  ...dontCompleteLiteral
 ];
 
 export const doCompleteExpression = [
@@ -108,62 +104,8 @@ export function ifExpression(completionSource: CompletionSource) : CompletionSou
   });
 }
 
-export function ifExpressionOrIdentifier(completionSource: CompletionSource) : CompletionSource {
-  return ifNode(completionSource, {
-    include: doCompleteExpression,
-    exclude: dontCompleteLiteral
-  });
-}
-
-export function combineCompletionSources(sources: CompletionSource[]) : CompletionSource {
-
-  return async (context) => {
-    const results = await Promise.all(
-      sources.map(source => source(context))
-    );
-
-    const matchedResults = results.filter(r => !!r);
-
-    if (!matchedResults.length) {
-      return null;
-    }
-
-    if (matchedResults.length === 1) {
-      return matchedResults[0];
-    }
-
-    return {
-      from: Math.min(...matchedResults.map(r => r.from)),
-      options: matchedResults.flatMap(r => r.options)
-    };
-  };
-}
-
 export function snippetCompletion(snippets: readonly Completion[]) : CompletionSource {
-
-  const taggedSnippets = snippets.map(s => ({ ...s, type: 'text' }));
-
-  // split literal completions from other completions
-  // literal completions may appear in place of <Identifier> nodes,
-  // other snippets may only appear in place of <Expression> nodes
-  const literalSnippets = taggedSnippets.filter(s => s.detail === 'literal');
-  const regularSnippets = taggedSnippets.filter(s => s.detail !== 'literal');
-
-  const sources: CompletionSource[] = [];
-
-  if (regularSnippets.length) {
-    sources.push(ifExpression(
-      completeFromList(regularSnippets)
-    ));
-  }
-
-  if (literalSnippets.length) {
-    sources.push(ifExpressionOrIdentifier(
-      completeFromList(literalSnippets)
-    ));
-  }
-
-  return combineCompletionSources(sources);
+  return ifExpression(completeFromList(snippets.map(s => ({ ...s, type: 'text' }))));
 }
 
 export function matchLeft(node: SyntaxNode, position: number, nodes: (string|undefined)[]) : SyntaxNode | null {

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -105,7 +105,7 @@ export function ifExpression(completionSource: CompletionSource) : CompletionSou
 }
 
 export function snippetCompletion(snippets: readonly Completion[]) : CompletionSource {
-  return ifExpression(completeFromList(snippets.map(s => ({ ...s, type: 'text' }))));
+  return ifExpression(completeFromList(snippets));
 }
 
 export function matchLeft(node: SyntaxNode, position: number, nodes: (string|undefined)[]) : SyntaxNode | null {

--- a/test/autocomplete-spec.ts
+++ b/test/autocomplete-spec.ts
@@ -27,13 +27,26 @@ describe('feel completion', function() {
     }));
 
 
-    it('filteres matching', check({
+    it('filteres matching by full term', check({
       doc: 'if',
       expectedCompletions: [
         { label: 'context', excluded: true },
         { label: 'function', excluded: true },
         { label: 'for', excluded: true },
         { label: 'if' },
+        { label: 'some', excluded: true },
+        { label: 'every', excluded: true }
+      ]
+    }));
+
+
+    it('filteres matching by partial term', check({
+      doc: 'fun',
+      expectedCompletions: [
+        { label: 'context', excluded: true },
+        { label: 'function' },
+        { label: 'for', excluded: true },
+        { label: 'if', excluded: true },
         { label: 'some', excluded: true },
         { label: 'every', excluded: true }
       ]
@@ -248,7 +261,7 @@ describe('feel completion', function() {
     }));
 
 
-    it('completes only literal completions inside identifier', check({
+    it('completes literal and regular completions inside identifier', check({
       doc: 'my',
       selection: 2,
       config: {
@@ -260,7 +273,7 @@ describe('feel completion', function() {
         ]
       },
       expectedCompletions: [
-        { label: 'myRegular', excluded: true },
+        { label: 'myRegular' },
         { label: 'myLiteral' }
       ]
     }));


### PR DESCRIPTION
### Which issue does this PR address?

Ensures that snippets are reasonably proposed on partial tokens - `fun` proposes function snippet, etc:

<img width="1181" height="548" alt="capture wNpowM_optimized" src="https://github.com/user-attachments/assets/1f3ee99a-166e-490c-8f81-86f59cb0d73d" />

Partially reverts https://github.com/nikku/lang-feel/pull/34, which was over eager to ship a local fix :upside_down_face: 
